### PR TITLE
bugfix(TESB-31889): wrong pom.version instead of upstream.version

### DIFF
--- a/activemq-karaf/src/main/resources/features.xml
+++ b/activemq-karaf/src/main/resources/features.xml
@@ -61,7 +61,7 @@
       <bundle>mvn:org.apache.activemq/activemq-blueprint/${upstream.version}</bundle>
     </feature>
 
-    <feature name="activemq-amqp-client" version="${pom.version}" description="ActiveMQ AMQP protocol client libraries">
+    <feature name="activemq-amqp-client" version="${upstream.version}" description="ActiveMQ AMQP protocol client libraries">
       <bundle>mvn:io.netty/netty-common/${qpid-jms-netty-version}</bundle>
       <bundle>mvn:io.netty/netty-transport/${qpid-jms-netty-version}</bundle>
       <bundle>mvn:io.netty/netty-transport-native-epoll/${qpid-jms-netty-version}</bundle>


### PR DESCRIPTION
Keeping same feature tesb version.