### PR TITLE
fix(DPE-2715): fix activemq blueprint

### DIFF
--- a/activemq-blueprint/pom.xml
+++ b/activemq-blueprint/pom.xml
@@ -59,11 +59,11 @@
           <configuration>
               <instructions>
                   <Import-Package>
-                      org.apache.xbean*;version="[3.13,5)",
+                      !org.apache.xbean*;version="[3.13,5)",
                       org.apache.aries.blueprint.*;version="[1.0,2)",
                       *
                   </Import-Package>
-                  <Fragment-Host>org.apache.activemq.activemq-osgi</Fragment-Host>
+                  <Fragment-Host>org.apache.activemq.osgi</Fragment-Host>
                   <_noee>true</_noee>
               </instructions>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <activemq-karaf.features.tesb.version>6.2.2.20260322</activemq-karaf.features.tesb.version>
     <activemq-karaf.tesb.version>${activemq-karaf.features.tesb.version}</activemq-karaf.tesb.version>
-    <activemq-blueprint.tesb.version>6.2.2.20230322</activemq-blueprint.tesb.version>
+    <activemq-blueprint.tesb.version>6.2.2.20260322</activemq-blueprint.tesb.version>
     <activemq-osgi.tesb.version>6.2.2.20260322</activemq-osgi.tesb.version>
     <activemq-pool.tesb.version>6.2.2.202560322</activemq-pool.tesb.version>
     <activemq-web-console.tesb.version>6.2.2.20260322</activemq-web-console.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-2715](https://qlik-dev.atlassian.net/browse/DPE-2715)

🔍 **What is the problem this PR is trying to solve?**
activemq blueprint feature cannot be installed

🚀 **What is the chosen solution to this problem?**
fix version of the bundle : 2023 => 2026
remove the import of `org.apache.xbean` : this package is in the host bundle, and does not need to be imported
set the right bundle host name : `org.apache.activemq.osgi`

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR



[DPE-2715]: https://qlik-dev.atlassian.net/browse/DPE-2715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ